### PR TITLE
feat: cards enter the field at the beginning of the next turn.

### DIFF
--- a/contracts/src/components.cairo
+++ b/contracts/src/components.cairo
@@ -62,7 +62,7 @@ struct Game {
     outcome: Option<Outcome>,
 }
 
-#[derive(Component, Copy, Drop, Serde, SerdeLen)]
+#[derive(Component, Copy, Drop, Serde, SerdeLen, PrintTrait)]
 struct Player {
     #[key]
     game_id: felt252,
@@ -102,6 +102,23 @@ impl OptionPlacementSerdeLen of dojo::SerdeLen<Option<Placement>> {
     fn len() -> usize {
         // 1 (variant id size) + 2 (value contained by the variant)
         3
+    }
+}
+
+#[generate_trait]
+impl PlayerImpl of PlayerTrait {
+    /// Moves a card on the field if necessary.
+    #[inline(always)]
+    fn update_card_placement(ref self: Option<Placement>) {
+        self = match self {
+            Option::Some(placement) => {
+                match placement {
+                    Placement::Side(card_id) => Option::Some(Placement::Field(card_id)),
+                    Placement::Field(card_id) => Option::Some(Placement::Field(card_id)),
+                }
+            },
+            Option::None => Option::None
+        }
     }
 }
 

--- a/contracts/src/systems/end_turn.cairo
+++ b/contracts/src/systems/end_turn.cairo
@@ -3,10 +3,10 @@ mod end_turn_system {
     use array::ArrayTrait;
 
     use dojo::world::Context;
-    use tsubasa::components::{Game, Player, Outcome};
+
+    use tsubasa::components::{Game, Player, Outcome, PlayerTrait, Placement};
     use tsubasa::events::EndTurn;
     use tsubasa::systems::check_turn;
-
 
     /// Ends a turn and increments the energy of the player who ended the turn.
     ///
@@ -21,12 +21,25 @@ mod end_turn_system {
 
         game.turn += 1;
 
-        emit!(ctx.world, EndTurn { game_id, turn: game.turn })
+        emit!(ctx.world, EndTurn { game_id, turn: game.turn });
 
         // Increments the energy of the player 
         let mut player = get!(ctx.world, (game_id, ctx.origin), Player);
         player.remaining_energy = game.turn / 2 + 2;
+        let opponent_address = if game.player1 == ctx.origin {
+            game.player2
+        } else {
+            game.player1
+        };
+        let mut opponent = get!(ctx.world, (game_id, opponent_address), Player);
+
+        opponent.goalkeeper.update_card_placement();
+        opponent.defender.update_card_placement();
+        opponent.midfielder.update_card_placement();
+        opponent.attacker.update_card_placement();
+
         set!(ctx.world, (player));
+        set!(ctx.world, (opponent));
 
         // End the Game
         // If one reached score 2, set winner 


### PR DESCRIPTION
- Updated the card’s status at the end of the player turn.
I checked with @ayushtom for the game app, we can queue the card's status in the cache to display on next turn, so there is no problem to update the card's status in the end_turn system so that the card appears on the next turn of the player
- I did the test inside the end_turn test file, but I can put it inside the place_card test file if you find it more appropriate.